### PR TITLE
Update Sftp.php to fix line endings for private key (identity file)

### DIFF
--- a/sysutils/sftp-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Sftp.php
+++ b/sysutils/sftp-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Sftp.php
@@ -178,7 +178,7 @@ class Sftp extends Base implements IBackupProvider
             mkdir($confdir);
         }
         if (!is_file($identfile) || file_get_contents($identfile) != $this->model->privkey) {
-            File::file_put_contents($identfile, $this->model->privkey, 0600);
+            File::file_put_contents($identfile,  preg_replace('/[\r\n]+/', "\n", $this->model->privkey), 0600);
         }
         return $identfile;
     }


### PR DESCRIPTION
Remove errorneous CRLF line endings and replace with LF.

See issue https://github.com/opnsense/plugins/issues/4582.